### PR TITLE
7: Fix Algolia search crawler to work properly to re-index content

### DIFF
--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Homebrew
-        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: Run Scraper
         run: |
           brew install jq

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -3,10 +3,6 @@ name: Algolia Search
 on:
   schedule:
     - cron: '0 10 * * *'
-  # TODO: Remove trigger from push event when search index scraper is fixed
-  push:
-    branches:
-      - '7-fix-search'
 
 jobs:
   build:

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install jq
-+       run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: Run Scraper
-        run: docker run -e "APPLICATION_ID=${{ secrets.ALGOLIA_APP_ID }}" -e "API_KEY=${{ secrets.API_KEY }}" -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper
+        run: |
+          brew install jq
+          docker run -e "APPLICATION_ID=${{ secrets.ALGOLIA_APP_ID }}" -e "API_KEY=${{ secrets.API_KEY }}" -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -16,5 +16,4 @@ jobs:
       - name: Install jq
 +       run: sudo apt-get update && sudo apt-get install -y jq
       - name: Run Scraper
-        run: |
-          docker run -e "APPLICATION_ID=${{ secrets.ALGOLIA_APP_ID }}" -e "API_KEY=${{ secrets.API_KEY }}" -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper
+        run: docker run -e "APPLICATION_ID=${{ secrets.ALGOLIA_APP_ID }}" -e "API_KEY=${{ secrets.API_KEY }}" -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -3,12 +3,18 @@ name: Algolia Search
 on:
   schedule:
     - cron: '0 10 * * *'
+  # TODO: Remove trigger from push event when search index scraper is fixed
+  push:
+    branches:
+      - '7-fix-search'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Homebrew
+        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       - name: Run Scraper
         run: |
           brew install jq

--- a/.github/workflows/search.yaml
+++ b/.github/workflows/search.yaml
@@ -12,11 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+      - uses: actions/checkout@v4
+      - name: Install jq
++       run: sudo apt-get update && sudo apt-get install -y jq
       - name: Run Scraper
         run: |
-          brew install jq
           docker run -e "APPLICATION_ID=${{ secrets.ALGOLIA_APP_ID }}" -e "API_KEY=${{ secrets.API_KEY }}" -e "CONFIG=$(cat ./config.json | jq -r tostring)" algolia/docsearch-scraper

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See https://www.npmjs.com/package/typedoc-plugin-markdown for details.
 
 # How to Update search indices with algolia
 
-- Create an .env file with `APPLICATION_ID` and the `API_KEY` (write access). 
+- Create an .env file with `APPLICATION_ID` and the `API_KEY` (Admin API Key w/ write access, should be kept secret). 
 If you don't have those, one for the Engineering Managers should be able to help you.
 - Edit config.json file if needed:
     - Start url from updated website

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,7 @@ module.exports = {
       additionalLanguages: ['solidity'],
     },
     algolia: {
-      apiKey: '32465e2ab6f7554ff014e64c0d92171c',
+      apiKey: '32465e2ab6f7554ff014e64c0d92171c', //  Search-Only API Key (Public & safe to commit)
       indexName: 'v3-docs',
       appId: 'S0IDD0YGLZ',
     },


### PR DESCRIPTION
### Description
- **Fixes**
	- Fixed Github Actions to use correct API key (Admin API Key)

- **Chores**
	- Added a step to install Homebrew before running the scraper.
	- Updated checkout action to the latest version for improved performance and security.
  
- **Documentation**
	- Clarified instructions for creating technical references and updating search indices in the README.
	- Specified the need for an Admin API Key for running the Algolia DocSearch scraper.
 
<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR
#7 
<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?
The crawl worked locally and it's working in [this build](https://github.com/sanctuarycomputer/uniswap-docs/actions/runs/11918637684/job/33216523681) that was triggered with a push event that I added to this branch for testing (since removed)
<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots
<img width="1508" alt="Screenshot 2024-11-19 at 6 38 37 PM" src="https://github.com/user-attachments/assets/d8c8fa3b-7adc-4aa7-9e9b-378d39211dab">

<!--- When appropriate, upload screenshots. -->

### Follow-up PR
When we merge this to https://github.com/Uniswap/docs, we need to ask the Uniswap developers to update the `API Key`  secret in the Github Actions env to the Algolia Admin API Key.
<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
